### PR TITLE
レイアウト見直し

### DIFF
--- a/src/components/templates/BookCard.tsx
+++ b/src/components/templates/BookCard.tsx
@@ -4,20 +4,20 @@ import LinkText from "../parts/LinkText";
 const BookCard: React.FC = () => {
     return (
         <div className="bg-white rounded overflow-hidden shadow-lg flex">
-            <img className="w-1/2 h-48" src={phpBookImage} alt="bookImage" />
+            <img className="w-[40%] h-48" src={phpBookImage} alt="bookImage" />
             <div className="px-6 py-4 flex flex-col justify-center">
                 <div className="font-bold text-xl mb-2">PHPの絵本</div>
-                <div className="mr-2 ml-2 mt-2">
+                <div className="ml-2 mt-2">
                     <LinkText
                         link="/book/1/edit"
-                        name="編集"
+                        name="編集する >"
                         size="lg"
                     />
                 </div>
-                <div className="mr-2 ml-2 mt-2">
+                <div className="ml-2 mt-2">
                     <LinkText
                         link="/book/1/study/create"
-                        name="学習登録"
+                        name="学習登録する >"
                         size="lg"
                     />
                 </div>

--- a/src/components/templates/StudiedBookHistoryCard.tsx
+++ b/src/components/templates/StudiedBookHistoryCard.tsx
@@ -13,7 +13,7 @@ const StudiedBookHistoryCard: React.FC = () => {
                 <div className="mr-2 ml-2 mt-2">
                     <LinkText
                         link="/studied-history-books/1/show"
-                        name="履歴"
+                        name="履歴を見る >"
                         size="lg"
                     />
                 </div>

--- a/src/components/templates/StudyingBookCard.tsx
+++ b/src/components/templates/StudyingBookCard.tsx
@@ -14,7 +14,7 @@ const StudyingBookCard: React.FC = () => {
                 <div className="mr-2 ml-2 mt-2">
                     <LinkText
                         link="/studying-books/1/record"
-                        name="記録をつける"
+                        name="記録をつける >"
                         size="lg"
                     />
                 </div>

--- a/src/components/views/StudiedBookHistoryShowView.tsx
+++ b/src/components/views/StudiedBookHistoryShowView.tsx
@@ -1,25 +1,35 @@
+import LinkText from "../parts/LinkText";
 import BookDetailCard from "../templates/BookDetailCard";
 import StudiedBookHistoryDetailCard from "../templates/StudiedBookHistoryDetailCard";
 
 const StudiedBookHistoryShowView: React.FC = () => {
     return (
-        <div className="max-w-xl mx-auto">
-            <div className="flex justify-center mt-12 mb-12">
-                <div className="w-full">
-                    <BookDetailCard />
+        <>
+            <div className="mt-6">
+                <LinkText
+                        link="/studied-history-books"
+                        name="< 戻る"
+                        size="base"
+                    />
+            </div>
+            <div className="max-w-xl mx-auto">
+                <div className="flex justify-center mt-12 mb-12">
+                    <div className="w-full">
+                        <BookDetailCard />
+                    </div>
+                </div>
+                <div className="flex justify-center mb-6 mt-6">
+                    <div className="w-full">
+                        <StudiedBookHistoryDetailCard />
+                    </div>
+                </div>
+                <div className="flex justify-center mb-6 mt-6">
+                    <div className="w-full">
+                        <StudiedBookHistoryDetailCard />
+                    </div>
                 </div>
             </div>
-            <div className="flex justify-center mb-6 mt-6">
-                <div className="w-full">
-                    <StudiedBookHistoryDetailCard />
-                </div>
-            </div>
-            <div className="flex justify-center mb-6 mt-6">
-                <div className="w-full">
-                    <StudiedBookHistoryDetailCard />
-                </div>
-            </div>
-        </div>
+        </>
     );
 };
 

--- a/src/components/views/StudyBookCreateView.tsx
+++ b/src/components/views/StudyBookCreateView.tsx
@@ -1,9 +1,18 @@
+import LinkText from "../parts/LinkText";
 import BookDetailCard from "../templates/BookDetailCard";
 import StudyBookFormCard from "../templates/StudyBookFormCard";
 
 const StudyBookCreateView: React.FC = () => {
     return (
-        <div className="max-w-xl mx-auto">
+        <>
+            <div className="mt-6">
+                <LinkText
+                    link="/shelves"
+                    name="< 戻る"
+                    size="base"
+                />
+            </div>
+            <div className="max-w-xl mx-auto">
             <div className="flex justify-center mt-12 mb-12">
                 <div className="w-full">
                     <BookDetailCard />
@@ -15,6 +24,7 @@ const StudyBookCreateView: React.FC = () => {
                 </div>
             </div>
         </div>
+        </>
     );
 };
 

--- a/src/components/views/StudyingBookRecordView.tsx
+++ b/src/components/views/StudyingBookRecordView.tsx
@@ -1,9 +1,18 @@
+import LinkText from "../parts/LinkText";
 import BookDetailCard from "../templates/BookDetailCard";
 import StudyingBookRecordForm from "../templates/StudyingBookRecordForm";
 
 const StudyingBookRecordView: React.FC = () => {
+
     return (
         <>
+            <div className="mt-6">
+                <LinkText
+                        link="/studying-books"
+                        name="< 戻る"
+                        size="base"
+                    />
+            </div>
             <div className="max-w-xl mx-auto">
                 <div className="flex justify-center mt-12 mb-12">
                     <div className="w-full">


### PR DESCRIPTION
棚一覧のカードの改行される問題は画像のサイズを変更で対応
戻るリンクの実装
リンクに>をつけた